### PR TITLE
Integrated dark/light mode icon with fully working functionality

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,12 +8,18 @@
       "name": "campusunify-client",
       "version": "1.0.0",
       "dependencies": {
+        "@chakra-ui/react": "^2.9.5",
+        "@emotion/react": "^11.13.3",
+        "@emotion/styled": "^11.13.0",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.36.1",
         "axios": "^1.6.8",
         "date-fns": "^3.6.0",
         "file-saver": "^2.0.5",
         "firebase": "^10.10.0",
+        "framer-motion": "^11.11.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
@@ -70,7 +76,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
       "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.25.7",
@@ -154,7 +159,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
       "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.7",
@@ -285,7 +289,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
       "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.7",
@@ -405,7 +408,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
       "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -415,7 +417,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
       "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -464,7 +465,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
       "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.7",
@@ -480,7 +480,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -493,7 +492,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -508,7 +506,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -518,14 +515,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -535,7 +530,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -545,7 +539,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -558,7 +551,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
       "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.7"
@@ -2222,7 +2214,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
       "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2235,7 +2226,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
       "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.7",
@@ -2250,7 +2240,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
       "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.7",
@@ -2269,7 +2258,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2279,7 +2267,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
       "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.7",
@@ -2289,6 +2276,235 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@chakra-ui/anatomy": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.3.tgz",
+      "integrity": "sha512-Sy2VAG0WrzkQE40Y0fY406c6AlyqFxAc7j6fDz8Wwotz9veAvm+y5UgFUyhZ6FoYNAjDMPQ7JCcN7OGz74pNlA=="
+    },
+    "node_modules/@chakra-ui/hooks": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.3.3.tgz",
+      "integrity": "sha512-nvqQfR+u0qAJ2/mdGF1XTrnfW9WahSsOc62E/xtRm5hPClfkxPCIXDuw0C17lZ2RYfg/hxsYKLJCGnQWZcC/7w==",
+      "dependencies": {
+        "@chakra-ui/utils": "2.1.3",
+        "@zag-js/element-size": "0.31.1",
+        "copy-to-clipboard": "3.3.3",
+        "framesync": "6.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.9.5.tgz",
+      "integrity": "sha512-g4CIow3I424Va6f/v5wIA+6nAbvsALARST/uqUmGMJJ4qDa95FpJx0XNJzlcFABBkuNDWplciCTUL0whKReL9w==",
+      "dependencies": {
+        "@chakra-ui/hooks": "2.3.3",
+        "@chakra-ui/styled-system": "2.10.3",
+        "@chakra-ui/theme": "3.4.3",
+        "@chakra-ui/utils": "2.1.3",
+        "@popperjs/core": "^2.11.8",
+        "@zag-js/focus-visible": "^0.31.1",
+        "aria-hidden": "^1.2.3",
+        "react-fast-compare": "3.2.2",
+        "react-focus-lock": "^2.9.6",
+        "react-lorem-component": "^0.13.0",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">=11",
+        "@emotion/styled": ">=11",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/styled-system": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.10.3.tgz",
+      "integrity": "sha512-rU4sG712pnp3Qrc8XT5AKcMhZjByXp1IrErLJ8wmiez2v8hAl/Dv8roK2BTqd4GfkJOrtkyfq2e2ZcDWjbd9Dw==",
+      "dependencies": {
+        "@chakra-ui/utils": "2.1.3",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@chakra-ui/theme": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.3.tgz",
+      "integrity": "sha512-WxGk5wEMr8x/YmR99TfVcnt+qsHt9qy5FJycPgcKoL8blQiZ+v/rLhdWhXvu8K03DyfAoLkQDh2guVl+wKFfHA==",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.3.3",
+        "@chakra-ui/theme-tools": "2.2.3",
+        "@chakra-ui/utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.8.0"
+      }
+    },
+    "node_modules/@chakra-ui/theme-tools": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.3.tgz",
+      "integrity": "sha512-9fbBh4YaF8k1puovMnvdZtoVxQd1IKlRvWQBmIzXoae3KSJi9p1znRLzEX+Qjvph15dFCa2Q4h1gynI+HOh8oQ==",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.3.3",
+        "@chakra-ui/utils": "2.1.3",
+        "color2k": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.0.0"
+      }
+    },
+    "node_modules/@chakra-ui/utils": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.1.3.tgz",
+      "integrity": "sha512-qIuyEg1ThVrUAnkV5nOngMDxUVCKavC04LfuraOCS1PHU4zhU4urJC2FURriALIQSgy6LpegASjvRzi7CIDDQQ==",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.9",
+        "lodash.mergewith": "4.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+      "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.2.0",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.13.1",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+      "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.0",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.13.3",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
+      "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/cache": "^11.13.0",
+        "@emotion/serialize": "^1.3.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+        "@emotion/utils": "^1.4.0",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.2.tgz",
+      "integrity": "sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
+      "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.0",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+        "@emotion/utils": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+      "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.1.tgz",
+      "integrity": "sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -3320,6 +3536,37 @@
       "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
+      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -3489,7 +3736,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -3504,7 +3750,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3514,7 +3759,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3524,14 +3768,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3632,6 +3874,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -4290,6 +4541,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ=="
+    },
+    "node_modules/@types/lodash.mergewith": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
@@ -4303,7 +4567,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -4640,6 +4903,24 @@
         "vite": "^4 || ^5"
       }
     },
+    "node_modules/@zag-js/dom-query": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
+      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg=="
+    },
+    "node_modules/@zag-js/element-size": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
+      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ=="
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
+      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "dependencies": {
+        "@zag-js/dom-query": "0.31.1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -4738,6 +5019,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.1.3",
@@ -5019,7 +5311,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -5206,7 +5497,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5330,6 +5620,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5388,6 +5683,14 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.38.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
@@ -5406,7 +5709,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -5417,6 +5719,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/create-react-class": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
+      "dependencies": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -5528,7 +5839,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5627,6 +5937,11 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -5692,7 +6007,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -5937,7 +6251,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6590,6 +6903,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6664,6 +6982,17 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/focus-lock": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -6740,6 +7069,43 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.1.tgz",
+      "integrity": "sha512-Ucr9eHSrk0d+l6vyl9fvq6omh/PAWHjS+PlczpsoUdhJo1TuF3ULWJNuAMnpWQ1dGyPOyoUVuYlUKjE/s8dyCA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framesync": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+      "dependencies": {
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6766,7 +7132,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6838,6 +7203,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-symbol-description": {
@@ -7052,13 +7425,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/http-parser-js": {
@@ -7087,7 +7467,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -7144,6 +7523,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -7182,7 +7569,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -7261,7 +7647,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7654,7 +8039,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -7674,7 +8058,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -7778,7 +8161,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7824,6 +8206,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
@@ -7840,6 +8227,17 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lorem-ipsum": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.6.tgz",
+      "integrity": "sha512-Rx4XH8X4KSDCKAVvWGYlhAfNqdUP5ZdT4rRyf0jjrvWgtViZimDIlopWNfn/y3lGM5K4uuiAoY28TaD+7YKFrQ==",
+      "dependencies": {
+        "minimist": "~1.2.0"
+      },
+      "bin": {
+        "lorem-ipsum": "bin/lorem-ipsum.bin.js"
       }
     },
     "node_modules/lru-cache": {
@@ -7914,7 +8312,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7934,7 +8331,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -8013,7 +8409,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8226,7 +8621,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -8239,7 +8633,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -8288,7 +8681,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -8319,7 +8711,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8329,7 +8720,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
       "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -8594,7 +8984,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8675,6 +9064,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -8686,6 +9086,33 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.2.tgz",
+      "integrity": "sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.5",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.2",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-hot-toast": {
@@ -8717,8 +9144,66 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-lorem-component": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-lorem-component/-/react-lorem-component-0.13.0.tgz",
+      "integrity": "sha512-4mWjxmcG/DJJwdxdKwXWyP2N9zohbJg/yYaC+7JffQNrKj3LYDpA/A4u/Dju1v1ZF6Jew2gbFKGb5Z6CL+UNTw==",
+      "dependencies": {
+        "create-react-class": "^15.5.3",
+        "lorem-ipsum": "^1.0.3",
+        "object-assign": "^4.1.0",
+        "seedable-random": "0.0.1"
+      },
+      "peerDependencies": {
+        "react": "16.x"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-router": {
       "version": "6.26.2",
@@ -8750,6 +9235,28 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -8821,7 +9328,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
@@ -8910,7 +9416,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -8928,7 +9433,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9088,6 +9592,11 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/seedable-random": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/seedable-random/-/seedable-random-0.0.1.tgz",
+      "integrity": "sha512-uZWbEfz3BQdBl4QlUPELPqhInGEO1Q6zjzqrTDkd3j7mHaWWJo7h4ydr2g24a2WtTLk3imTLc8mPbBdQqdsbGw=="
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -9195,6 +9704,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -9420,6 +9937,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -9519,7 +10041,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9617,7 +10138,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9635,6 +10155,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -9801,21 +10326,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -9930,6 +10440,47 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -10235,7 +10786,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/client/package.json
+++ b/client/package.json
@@ -11,12 +11,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@chakra-ui/react": "^2.9.5",
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
+    "@fortawesome/free-solid-svg-icons": "^6.6.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",
     "axios": "^1.6.8",
     "date-fns": "^3.6.0",
     "file-saver": "^2.0.5",
     "firebase": "^10.10.0",
+    "framer-motion": "^11.11.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,9 +2,31 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
+import { createContext,useState } from 'react';
+
+const config = {
+  initialColorMode: 'light',
+  useSystemColorMode: false,
+};
+export const Context = createContext();
+
+const AppWrapper = ()=>{
+
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  return(
+      <Context.Provider value={{
+         isDarkMode,
+         setIsDarkMode
+      }}>
+ 
+
+  <App />
+
+      </Context.Provider>
+  )
+} 
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <AppWrapper/>
 );
+

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -6,8 +6,12 @@ import { usePayment } from '../features/cart/usePayment';
 import Spinner from '../ui/Spinner';
 import { formatCurrency, formatDateTimeDetailed } from '../utils/helpers';
 import { Link } from 'react-router-dom';
+import { Context } from '../main';
+import { useContext } from 'react';
 
 export default function Cart() {
+  const { isDarkMode, setIsDarkMode } = useContext(Context);
+
   const { cart, isLoading } = useCart();
   const { deleteFromCart, isDeleting } = useDeleteCartItem();
   const { clearCart, isClearing } = useClearCart();
@@ -15,7 +19,12 @@ export default function Cart() {
 
   return (
     <PageLayout>
-      <h2 className="text-3xl font-bold mt-4">Your Cart</h2>
+     <div className="w-[80%] mx-auto"
+      style={{
+        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
+        color: isDarkMode ? 'white' : 'black',
+      }}>
+     <h2 className="text-3xl font-bold mt-4">Your Cart</h2>
       {isLoading ? (
         <Spinner />
       ) : (
@@ -77,6 +86,7 @@ export default function Cart() {
           )}
         </div>
       )}
+     </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -10,7 +10,7 @@ import { Context } from '../main';
 import { useContext } from 'react';
 
 export default function Cart() {
-  const { isDarkMode, setIsDarkMode } = useContext(Context);
+  const { isDarkMode } = useContext(Context);
 
   const { cart, isLoading } = useCart();
   const { deleteFromCart, isDeleting } = useDeleteCartItem();
@@ -19,74 +19,83 @@ export default function Cart() {
 
   return (
     <PageLayout>
-     <div className="w-[80%] mx-auto"
-      style={{
-        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
-        color: isDarkMode ? 'white' : 'black',
-      }}>
-     <h2 className="text-3xl font-bold mt-4">Your Cart</h2>
-      {isLoading ? (
-        <Spinner />
-      ) : (
-        <div className="flex flex-col gap-4 mt-4">
-          {cart.eventIds.length === 0 ? (
-            <p className="mt-2">
-              There are no items present your cart!
-              <Link to="/events" className="text-blue-500 hover:text-blue-700">
-                {' '}
-                Add new items to your car &rarr;
-              </Link>
-            </p>
-          ) : (
-            <>
-              {cart.eventIds.map((event) => (
-                <div key={event._id} className="flex gap-4">
-                  <img
-                    src={event.cardImage}
-                    className="w-28 h-28 rounded-lg"
-                    alt=""
-                  />
-                  <div className="flex flex-col justify-between py-4">
-                    <p className="text-lg">{event.name}</p>
-                    <p className="text-primary-700 font-light">
-                      {formatCurrency(event.eventCharges)}
-                    </p>
-                    <p className="text-primary-700 font-light">
-                      {formatDateTimeDetailed(event.date)}
-                    </p>
-                  </div>
-                  <button
-                    className="justify-self-end self-center ml-auto bg-skin px-4 py-2 rounded-lg font-bold"
-                    disabled={isDeleting}
-                    onClick={() => deleteFromCart(event._id)}
+      <div
+        className={`w-[80%] mx-auto p-6 transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-800 text-white' : 'bg-gray-100 text-black'
+        }`}
+      >
+        <h2 className="text-3xl font-bold mt-4">Your Cart</h2>
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <div className="flex flex-col gap-4 mt-4">
+            {cart.eventIds.length === 0 ? (
+              <p className="mt-2">
+                There are no items present in your cart!
+                <Link
+                  to="/events"
+                  className="text-blue-500 hover:text-blue-700 ml-1"
+                >
+                  Add new items to your cart &rarr;
+                </Link>
+              </p>
+            ) : (
+              <>
+                {cart.eventIds.map((event) => (
+                  <div
+                    key={event._id}
+                    className="flex gap-4 items-center p-4 rounded-lg transition-colors duration-300 
+                               hover:bg-gray-200 dark:hover:bg-gray-700"
                   >
-                    Delete
+                    <img
+                      src={event.cardImage}
+                      className="w-28 h-28 rounded-lg object-cover"
+                      alt={event.name}
+                    />
+                    <div className="flex flex-col justify-between py-4 flex-1">
+                      <p className="text-lg">{event.name}</p>
+                      <p className="text-primary-700 dark:text-primary-400 font-light">
+                        {formatCurrency(event.eventCharges)}
+                      </p>
+                      <p className="text-primary-700 dark:text-primary-400 font-light">
+                        {formatDateTimeDetailed(event.date)}
+                      </p>
+                    </div>
+                    <button
+                      className="bg-red-600 text-white px-4 py-2 rounded-lg font-bold self-center ml-auto
+                                 transition-colors duration-300 hover:bg-red-500 disabled:opacity-50"
+                      disabled={isDeleting}
+                      onClick={() => deleteFromCart(event._id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                ))}
+                <p className="text-xl font-semibold">
+                  Total: {formatCurrency(cart.totalAmount)}
+                </p>
+                <div className="flex justify-end gap-4 mt-4">
+                  <button
+                    className="bg-yellow-500 px-4 py-2 rounded-lg font-bold transition-colors 
+                               duration-300 hover:bg-yellow-400 disabled:opacity-50"
+                    onClick={clearCart}
+                    disabled={isClearing}
+                  >
+                    Clear Cart
+                  </button>
+                  <button
+                    className="bg-primary-700 text-white px-4 py-2 rounded-lg font-bold 
+                               transition-colors duration-300 hover:bg-primary-600"
+                    onClick={initiatePayment}
+                  >
+                    Proceed to Checkout
                   </button>
                 </div>
-              ))}
-              <p className="text-xl font-semibold">
-                Total: {formatCurrency(cart.totalAmount)}
-              </p>
-              <div className="flex justify-end gap-4">
-                <button
-                  className="bg-skin px-4 py-2 rounded-lg font-bold"
-                  onClick={clearCart}
-                  disabled={isClearing}
-                >
-                  Clear Cart
-                </button>
-                <button
-                  className="bg-primary-700 px-4 py-2 rounded-lg font-bold text-white"
-                  onClick={initiatePayment}
-                >
-                  Proceed to Checkout
-                </button>
-              </div>
-            </>
-          )}
-        </div>
-      )}
-     </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/Event.jsx
+++ b/client/src/pages/Event.jsx
@@ -1,4 +1,4 @@
-import { useState,useContext } from 'react';
+import { useState, useContext } from 'react';
 import { useEvent } from '../features/events/useEvent';
 import PageLayout from '../styles/PageLayout';
 import PageNotFound from '../ui/PageNotFound';
@@ -15,7 +15,6 @@ export default function Event() {
   const [activeTab, setActiveTab] = useState('info');
   const { isDarkMode } = useContext(Context);
 
-
   if (!isLoadingOne && !event)
     return (
       <PageLayout>
@@ -25,73 +24,73 @@ export default function Event() {
 
   return (
     <PageLayout>
-    <div  className="w-[80%] mx-auto"
-      style={{
-        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
-        color: isDarkMode ? 'white' : 'black',
-      }}>
-    {isLoadingOne || isLoadingTwo ? (
-        <Spinner />
-      ) : (
-        <>
-          <div className="relative flex flex-col items-center px-4 sm:px-8">
-            <img
-              className="w-full sm:w-[75%] mx-auto rounded-lg shadow-md"
-              src={event.coverImage}
-              alt=""
-            />
-            <div className="absolute bottom-[10%] sm:bottom-[5%] left-[10%] sm:left-[15%] p-2 text-white">
-              <p className="text-xl sm:text-6xl font-bold leading-tight">
-                {event.name}
-              </p>
-              <p className="mt-2 text-sm sm:text-base">
-                {`Hosted by ${event.clubId.name}`}
-              </p>
+      <div
+        className={`w-[80%] mx-auto p-6 transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-800 text-white' : 'bg-gray-100 text-black'
+        }`}
+      >
+        {isLoadingOne || isLoadingTwo ? (
+          <Spinner />
+        ) : (
+          <>
+            <div className="relative flex flex-col items-center px-4 sm:px-8">
+              <img
+                className="w-full sm:w-[75%] mx-auto rounded-lg shadow-md"
+                src={event.coverImage}
+                alt={event.name}
+              />
+              <div className="absolute bottom-[10%] sm:bottom-[5%] left-[10%] sm:left-[15%] p-2 text-white">
+                <p className="text-xl sm:text-6xl font-bold leading-tight">
+                  {event.name}
+                </p>
+                <p className="mt-2 text-sm sm:text-base">
+                  {`Hosted by ${event.clubId.name}`}
+                </p>
+              </div>
             </div>
-          </div>
-          <h2 className="text-4xl mt-4 font-bold">{event.name}</h2>
-          <div className="w-full mt-4 flex items-center gap-4 border-b-2 p-4 border-primary-100">
-            <button
-              className={`font-semibold hover:text-black pb-2 ${
-                activeTab === 'info'
-                  ? 'text-black border-b-2 border-primary-700'
-                  : 'text-primary-900'
-              }`}
-              onClick={() => setActiveTab('info')}
-            >
-              Event Information
-            </button>
-            <button
-              className={`font-semibold hover:text-black pb-2 ${
-                activeTab === 'daydetails'
-                  ? 'text-black border-b-2 border-primary-700'
-                  : 'text-primary-900'
-              }`}
-              onClick={() => setActiveTab('daydetails')}
-            >
-              Daily Event Details
-            </button>
-            {user.role === 'club' && (
+            <h2 className="text-4xl mt-4 font-bold">{event.name}</h2>
+            <div className="w-full mt-4 flex items-center gap-4 border-b-2 p-4 transition-colors duration-300 border-gray-300 dark:border-gray-600">
               <button
-                className={`font-semibold hover:text-black pb-2 ${
-                  activeTab === 'registrations'
-                    ? 'text-black border-b-2 border-primary-700'
-                    : 'text-primary-900'
+                className={`font-semibold pb-2 transition-colors duration-300 ${
+                  activeTab === 'info'
+                    ? 'text-black dark:text-white border-b-2 border-primary-700'
+                    : 'text-primary-900 dark:text-primary-400 hover:text-black dark:hover:text-white'
                 }`}
-                onClick={() => setActiveTab('registrations')}
+                onClick={() => setActiveTab('info')}
               >
-                Registrations
+                Event Information
               </button>
+              <button
+                className={`font-semibold pb-2 transition-colors duration-300 ${
+                  activeTab === 'daydetails'
+                    ? 'text-black dark:text-white border-b-2 border-primary-700'
+                    : 'text-primary-900 dark:text-primary-400 hover:text-black dark:hover:text-white'
+                }`}
+                onClick={() => setActiveTab('daydetails')}
+              >
+                Daily Event Details
+              </button>
+              {user.role === 'club' && (
+                <button
+                  className={`font-semibold pb-2 transition-colors duration-300 ${
+                    activeTab === 'registrations'
+                      ? 'text-black dark:text-white border-b-2 border-primary-700'
+                      : 'text-primary-900 dark:text-primary-400 hover:text-black dark:hover:text-white'
+                  }`}
+                  onClick={() => setActiveTab('registrations')}
+                >
+                  Registrations
+                </button>
+              )}
+            </div>
+            {activeTab === 'info' && <EventInformationTab event={event} />}
+            {activeTab === 'daydetails' && <EventDaysTab event={event} />}
+            {activeTab === 'registrations' && (
+              <EventRegistrationsTab event={event} />
             )}
-          </div>
-          {activeTab === 'info' && <EventInformationTab event={event} />}
-          {activeTab === 'daydetails' && <EventDaysTab event={event} />}
-          {activeTab === 'registrations' && (
-            <EventRegistrationsTab event={event} />
-          )}
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/Event.jsx
+++ b/client/src/pages/Event.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState,useContext } from 'react';
 import { useEvent } from '../features/events/useEvent';
 import PageLayout from '../styles/PageLayout';
 import PageNotFound from '../ui/PageNotFound';
@@ -7,11 +7,14 @@ import { useUser } from '../features/authentication/useUser';
 import EventInformationTab from '../features/events/EventInformationTab';
 import EventDaysTab from '../features/events/EventDaysTab';
 import EventRegistrationsTab from '../features/events/EventRegistrationsTab';
+import { Context } from '../main';
 
 export default function Event() {
   const { event, isLoading: isLoadingOne } = useEvent();
   const { user, isLoading: isLoadingTwo } = useUser();
   const [activeTab, setActiveTab] = useState('info');
+  const { isDarkMode } = useContext(Context);
+
 
   if (!isLoadingOne && !event)
     return (
@@ -22,7 +25,12 @@ export default function Event() {
 
   return (
     <PageLayout>
-      {isLoadingOne || isLoadingTwo ? (
+    <div  className="w-[80%] mx-auto"
+      style={{
+        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
+        color: isDarkMode ? 'white' : 'black',
+      }}>
+    {isLoadingOne || isLoadingTwo ? (
         <Spinner />
       ) : (
         <>
@@ -83,6 +91,7 @@ export default function Event() {
           )}
         </>
       )}
+    </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/Events.jsx
+++ b/client/src/pages/Events.jsx
@@ -2,17 +2,20 @@ import PageLayout from '../styles/PageLayout';
 import SpinnerMini from '../ui/SpinnerMini';
 import SearchFilter from '../ui/SearchFilter';
 
-import { useState } from 'react';
+import { useState ,useContext} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from './../features/authentication/useUser';
 import { useEvents } from '../features/events/useEvents';
 import { formatDateTimeEvent } from '../utils/helpers';
 import AddEvent from '../features/events/AddEvent';
 import EventMenu from '../features/events/EventMenu';
+import { Context } from '../main';
 
 export default function Events() {
   const navigate = useNavigate();
   const { user } = useUser();
+  const { isDarkMode, setIsDarkMode } = useContext(Context);
+
 
   const { events = [], isLoading } = useEvents();
   const [searchQuery, setSearchQuery] = useState('');
@@ -59,7 +62,12 @@ export default function Events() {
 
   return (
     <PageLayout>
-      <h2 className="text-3xl font-bold mt-4">Events</h2>
+     <div className="w-[80%] mx-auto"
+      style={{
+        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
+        color: isDarkMode ? 'white' : 'black',
+      }}>
+     <h2 className="text-3xl font-bold mt-4">Events</h2>
       <SearchFilter
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
@@ -106,6 +114,7 @@ export default function Events() {
           </div>
         </>
       )}
+     </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/Events.jsx
+++ b/client/src/pages/Events.jsx
@@ -2,7 +2,7 @@ import PageLayout from '../styles/PageLayout';
 import SpinnerMini from '../ui/SpinnerMini';
 import SearchFilter from '../ui/SearchFilter';
 
-import { useState ,useContext} from 'react';
+import { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from './../features/authentication/useUser';
 import { useEvents } from '../features/events/useEvents';
@@ -14,8 +14,7 @@ import { Context } from '../main';
 export default function Events() {
   const navigate = useNavigate();
   const { user } = useUser();
-  const { isDarkMode, setIsDarkMode } = useContext(Context);
-
+  const { isDarkMode } = useContext(Context);
 
   const { events = [], isLoading } = useEvents();
   const [searchQuery, setSearchQuery] = useState('');
@@ -62,59 +61,59 @@ export default function Events() {
 
   return (
     <PageLayout>
-     <div className="w-[80%] mx-auto"
-      style={{
-        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
-        color: isDarkMode ? 'white' : 'black',
-      }}>
-     <h2 className="text-3xl font-bold mt-4">Events</h2>
-      <SearchFilter
-        searchQuery={searchQuery}
-        setSearchQuery={setSearchQuery}
-        categoryQuery={categoryQuery}
-        setCategoryQuery={setCategoryQuery}
-        dateQuery={dateQuery}
-        setDateQuery={setDateQuery}
-        sortQuery={sortQuery}
-        setSortQuery={setSortQuery}
-      />
-      {isLoading ? (
-        <SpinnerMini />
-      ) : (
-        <>
-          {user.role === 'club' && <AddEvent />}
-          <div className="mt-4 flex flex-col gap-4 mb-24">
-            {filteredEvents.length === 0 ? (
-              <p className="text-xl">No events match your filters</p>
-            ) : (
-              filteredEvents.map((event) => (
-                <div key={event._id} className="flex gap-4">
-                  <div
-                    className="flex gap-4 hover:cursor-pointer"
-                    onClick={() => navigate(`/events/${event._id}`)}
-                  >
-                    <img
-                      src={event.cardImage}
-                      className="w-20 h-20 rounded-lg"
-                      alt="Event cover image"
-                    />
-                    <div className="flex flex-col justify-center">
-                      <p className="font-semibold">{event.name}</p>
-                      <p className="text-primary-900">
-                        {formatDateTimeEvent(event.date)}
-                      </p>
+      <div
+        className={`w-[80%] mx-auto transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-800 text-white' : 'bg-gray-50 text-gray-900'
+        }`}
+      >
+        <h2 className="text-3xl font-bold mt-4">Events</h2>
+        <SearchFilter
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          categoryQuery={categoryQuery}
+          setCategoryQuery={setCategoryQuery}
+          dateQuery={dateQuery}
+          setDateQuery={setDateQuery}
+          sortQuery={sortQuery}
+          setSortQuery={setSortQuery}
+        />
+        {isLoading ? (
+          <SpinnerMini />
+        ) : (
+          <>
+            {user.role === 'club' && <AddEvent />}
+            <div className="mt-4 flex flex-col gap-4 mb-24">
+              {filteredEvents.length === 0 ? (
+                <p className="text-xl">No events match your filters</p>
+              ) : (
+                filteredEvents.map((event) => (
+                  <div key={event._id} className="flex gap-4">
+                    <div
+                      className="flex gap-4 hover:cursor-pointer"
+                      onClick={() => navigate(`/events/${event._id}`)}
+                    >
+                      <img
+                        src={event.cardImage}
+                        className="w-20 h-20 rounded-lg"
+                        alt="Event cover image"
+                      />
+                      <div className="flex flex-col justify-center">
+                        <p className="font-semibold">{event.name}</p>
+                        <p className="text-primary-900">
+                          {formatDateTimeEvent(event.date)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="ml-auto justify-center my-auto">
+                      <EventMenu event={event} user={user} />
                     </div>
                   </div>
-                  <div className="ml-auto justify-center my-auto">
-                    <EventMenu event={event} user={user} />
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
-        </>
-      )}
-     </div>
+                ))
+              )}
+            </div>
+          </>
+        )}
+      </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -3,12 +3,20 @@ import { Link } from 'react-router-dom';
 import { useLatestEvents } from '../features/events/useLatestEvents';
 import SpinnerMini from '../ui/SpinnerMini';
 import { format } from 'date-fns';
+import { Context } from '../main';
+import { useContext } from 'react';
 
 export default function LandingPage() {
   const { isLoading, latestEvents } = useLatestEvents();
+  const { isDarkMode, setIsDarkMode } = useContext(Context);
 
   return (
-    <PageLayout>
+    <PageLayout >
+      <div className="w-[80%] mx-auto"
+      style={{
+        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
+        color: isDarkMode ? 'white' : 'black',
+      }}>
       <div className="relative flex flex-col items-center px-4 sm:px-8">
         <img
           className="w-full sm:w-[75%] mx-auto rounded-lg shadow-md"
@@ -172,6 +180,7 @@ export default function LandingPage() {
             </div>
           </div>
         </div>
+      </div>
       </div>
     </PageLayout>
   );

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -12,11 +12,10 @@ export default function LandingPage() {
 
   return (
     <PageLayout >
-      <div className="w-[80%] mx-auto"
-      style={{
-        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
-        color: isDarkMode ? 'white' : 'black',
-      }}>
+      <div  className={`w-[80%] mx-auto transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-800 text-white' : 'bg-gray-50 text-gray-900'
+        }`}
+      >
       <div className="relative flex flex-col items-center px-4 sm:px-8">
         <img
           className="w-full sm:w-[75%] mx-auto rounded-lg shadow-md"

--- a/client/src/pages/MyRegistrations.jsx
+++ b/client/src/pages/MyRegistrations.jsx
@@ -5,12 +5,13 @@ import { formatCurrency } from '../utils/helpers';
 import { Link } from 'react-router-dom';
 import api from '../services/api';
 import { formatDateTimeDetailed } from '../utils/helpers';
-import { useState } from 'react';
+import { useState,useContext } from 'react';
+import { Context } from '../main';
 
 export default function MyRegistrations() {
   const { isLoading, registrations } = useRegistrations();
   const [tab, setTab] = useState('all');
-
+  const { isDarkMode, setIsDarkMode } = useContext(Context);
   function handleDownloadTicket(registrationId) {
     api
       .get(`/bookings/generateTicket/${registrationId}`, {
@@ -55,7 +56,12 @@ export default function MyRegistrations() {
 
   return (
     <PageLayout>
-      <h2 className="text-3xl font-bold mt-4">Your Registrations</h2>
+    <div className="w-[80%] mx-auto"
+      style={{
+        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
+        color: isDarkMode ? 'white' : 'black',
+      }}>
+    <h2 className="text-3xl font-bold mt-4">Your Registrations</h2>
       {isLoading ? (
         <Spinner />
       ) : (
@@ -150,6 +156,7 @@ export default function MyRegistrations() {
           </div>
         </>
       )}
+    </div>
     </PageLayout>
   );
 }

--- a/client/src/pages/MyRegistrations.jsx
+++ b/client/src/pages/MyRegistrations.jsx
@@ -5,13 +5,14 @@ import { formatCurrency } from '../utils/helpers';
 import { Link } from 'react-router-dom';
 import api from '../services/api';
 import { formatDateTimeDetailed } from '../utils/helpers';
-import { useState,useContext } from 'react';
+import { useState, useContext } from 'react';
 import { Context } from '../main';
 
 export default function MyRegistrations() {
   const { isLoading, registrations } = useRegistrations();
   const [tab, setTab] = useState('all');
-  const { isDarkMode, setIsDarkMode } = useContext(Context);
+  const { isDarkMode } = useContext(Context); // Retrieve isDarkMode from context
+
   function handleDownloadTicket(registrationId) {
     api
       .get(`/bookings/generateTicket/${registrationId}`, {
@@ -27,7 +28,6 @@ export default function MyRegistrations() {
         link.setAttribute('download', filename);
 
         document.body.appendChild(link);
-
         link.click();
         link.parentNode.removeChild(link);
         window.URL.revokeObjectURL(url);
@@ -56,107 +56,108 @@ export default function MyRegistrations() {
 
   return (
     <PageLayout>
-    <div className="w-[80%] mx-auto"
-      style={{
-        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
-        color: isDarkMode ? 'white' : 'black',
-      }}>
-    <h2 className="text-3xl font-bold mt-4">Your Registrations</h2>
-      {isLoading ? (
-        <Spinner />
-      ) : (
-        <>
-          <div className="mt-4 border-b-2 p-2 border-skin flex gap-6">
-            <button
-              className={`font-semibold hover:text-black pb-1 ${
-                tab === 'all'
-                  ? 'text-black  border-b-2 border-primary-700'
-                  : 'text-primary-900'
-              }`}
-              onClick={() => setTab('all')}
-            >
-              All
-            </button>
-            <button
-              className={`font-semibold hover:text-black pb-1 ${
-                tab === 'upcoming'
-                  ? 'text-black  border-b-2 border-primary-700'
-                  : 'text-primary-900'
-              }`}
-              onClick={() => setTab('upcoming')}
-            >
-              Upcoming
-            </button>
-            <button
-              className={`font-semibold hover:text-black pb-1 ${
-                tab === 'past'
-                  ? 'text-black  border-b-2 border-primary-700'
-                  : 'text-primary-900'
-              }`}
-              onClick={() => setTab('past')}
-            >
-              Past
-            </button>
-          </div>
-          <div>
-            {filteredRegistrations.length === 0 ? (
-              <p className="mt-2">
-                You have not registered for any events yet!
-                <Link
-                  to="/events"
-                  className="text-blue-500 hover:text-blue-700"
-                >
-                  {' '}
-                  Browse for new events &rarr;
-                </Link>
-              </p>
-            ) : (
-              <>
-                <p className="text-xl mt-6 font-semibold">
-                  {tab.charAt(0).toUpperCase() + tab.slice(1)} events
+      <div
+       
+        className={`flex justify-between items-center mx-auto p-3 transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-black'
+        }`}
+      >
+        <h2 className="text-3xl font-bold mt-4">Your Registrations</h2>
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <>
+            <div className="mt-4 border-b-2 p-2 border-skin flex gap-6">
+              <button
+                className={`font-semibold hover:text-black pb-1 ${
+                  tab === 'all'
+                    ? 'text-black border-b-2 border-primary-700'
+                    : 'text-primary-900'
+                }`}
+                onClick={() => setTab('all')}
+              >
+                All
+              </button>
+              <button
+                className={`font-semibold hover:text-black pb-1 ${
+                  tab === 'upcoming'
+                    ? 'text-black border-b-2 border-primary-700'
+                    : 'text-primary-900'
+                }`}
+                onClick={() => setTab('upcoming')}
+              >
+                Upcoming
+              </button>
+              <button
+                className={`font-semibold hover:text-black pb-1 ${
+                  tab === 'past'
+                    ? 'text-black border-b-2 border-primary-700'
+                    : 'text-primary-900'
+                }`}
+                onClick={() => setTab('past')}
+              >
+                Past
+              </button>
+            </div>
+            <div>
+              {filteredRegistrations.length === 0 ? (
+                <p className="mt-2">
+                  You have not registered for any events yet!
+                  <Link
+                    to="/events"
+                    className="text-blue-500 hover:text-blue-700"
+                  >
+                    {' '}
+                    Browse for new events &rarr;
+                  </Link>
                 </p>
-                <div className="mt-2 rounded-lg border-2 border-skin text-center">
-                  <div className="grid grid-cols-[1fr_2fr_1fr_2fr_1fr_1fr] border-b p-3 items-center">
-                    <div className="font-bold">Event</div>
-                    <div className="font-bold">Date</div>
-                    <div className="font-bold">Total Charges</div>
-                    <div className="font-bold">Payment ID</div>
-                    <div className="font-bold">Status</div>
-                    <div className="font-bold">Actions</div>
-                  </div>
-
-                  {filteredRegistrations.map((registration) => (
-                    <div
-                      key={registration._id}
-                      className="grid grid-cols-[1fr_2fr_1fr_2fr_1fr_1fr] border-b p-3 items-center"
-                    >
-                      <p>{registration.eventId.name}</p>
-                      <p className="text-primary-900">
-                        {formatDateTimeDetailed(registration.eventId.date)}
-                      </p>
-                      <p className="text-primary-900">
-                        {formatCurrency(registration.paymentId.totalAmount)}
-                      </p>
-                      <p>{registration.paymentId.razorpayPaymentId}</p>
-                      <p className="bg-skin py-1 px-3 rounded-3xl self-center text-center">
-                        {registration.currentStatus.charAt(0).toUpperCase() +
-                          registration.currentStatus.slice(1)}
-                      </p>
-                      <button
-                        onClick={() => handleDownloadTicket(registration._id)}
-                        className="text-primary-900"
-                      >
-                        Download
-                      </button>
+              ) : (
+                <>
+                  <p className="text-xl mt-6 font-semibold">
+                    {tab.charAt(0).toUpperCase() + tab.slice(1)} events
+                  </p>
+                  <div className="mt-2 rounded-lg border-2 border-skin text-center">
+                    <div className="grid grid-cols-[1fr_2fr_1fr_2fr_1fr_1fr] border-b p-3 items-center">
+                      <div className="font-bold">Event</div>
+                      <div className="font-bold">Date</div>
+                      <div className="font-bold">Total Charges</div>
+                      <div className="font-bold">Payment ID</div>
+                      <div className="font-bold">Status</div>
+                      <div className="font-bold">Actions</div>
                     </div>
-                  ))}
-                </div>
-              </>
-            )}
-          </div>
-        </>
-      )}
-    </div>
+
+                    {filteredRegistrations.map((registration) => (
+                      <div
+                        key={registration._id}
+                        className="grid grid-cols-[1fr_2fr_1fr_2fr_1fr_1fr] border-b p-3 items-center"
+                      >
+                        <p>{registration.eventId.name}</p>
+                        <p className="text-primary-900">
+                          {formatDateTimeDetailed(registration.eventId.date)}
+                        </p>
+                        <p className="text-primary-900">
+                          {formatCurrency(registration.paymentId.totalAmount)}
+                        </p>
+                        <p>{registration.paymentId.razorpayPaymentId}</p>
+                        <p className="bg-skin py-1 px-3 rounded-3xl self-center text-center">
+                          {registration.currentStatus.charAt(0).toUpperCase() +
+                            registration.currentStatus.slice(1)}
+                        </p>
+                        <button
+                          onClick={() => handleDownloadTicket(registration._id)}
+                          className="text-primary-900"
+                        >
+                          Download
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          </>
+        )}
+      </div>
     </PageLayout>
   );
 }

--- a/client/src/styles/GlobalStyles.jsx
+++ b/client/src/styles/GlobalStyles.jsx
@@ -6,12 +6,11 @@ export default function GlobalStyles({ children }) {
 
   return (
     <div
-      className={`font-inter min-h-screen text-[#333] ${
-        isDarkMode ? 'bg-[#2D2D2D]' : 'bg-[#fcfaf8]'
+      className={`font-inter min-h-screen transition-colors duration-300 ${
+        isDarkMode ? 'bg-gray-800 text-white' : 'bg-gray-50 text-gray-900'
       }`}
     >
       {children}
     </div>
   );
 }
-

--- a/client/src/styles/GlobalStyles.jsx
+++ b/client/src/styles/GlobalStyles.jsx
@@ -1,7 +1,17 @@
+import { Context } from "../main";
+import { useContext } from "react";
+
 export default function GlobalStyles({ children }) {
+  const { isDarkMode } = useContext(Context);
+
   return (
-    <div className="font-inter min-h-screen text-[#333] bg-[#fcfaf8]">
+    <div
+      className={`font-inter min-h-screen text-[#333] ${
+        isDarkMode ? 'bg-[#2D2D2D]' : 'bg-[#fcfaf8]'
+      }`}
+    >
       {children}
     </div>
   );
 }
+

--- a/client/src/ui/Header.jsx
+++ b/client/src/ui/Header.jsx
@@ -1,11 +1,11 @@
-import { useState ,useContext} from 'react';
+import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { useUser } from '../features/authentication/useUser';
 import { Context } from '../main';
+
 export default function Header() {
   const { user } = useUser();
   const { isDarkMode, setIsDarkMode } = useContext(Context);
-
 
   // Function to toggle dark mode
   const toggleDarkMode = () => {
@@ -59,23 +59,18 @@ export default function Header() {
   );
 
   return (
-    <header
-      className="w-[80%] mx-auto"
-      style={{
-        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
-        color: isDarkMode ? 'white' : 'black',
-      }}
-    >
-      <div className="flex justify-between items-center mx-auto p-3">
+    <header className="w-[80%] mx-auto">
+      <div
+        className={`flex justify-between items-center mx-auto p-3 transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-black'
+        }`}
+      >
         <Link to={user ? '/events' : '/'}>
           <div className="flex gap-4 items-center">
             <img src="/logo.png" className="h-12 w-12" alt="" />
-            <h1
-              className="font-bold text-sm sm:text-xl flex flex-wrap"
-              style={{ color: isDarkMode ? '#fff' : '#000' }}
-            >
-              <span className="text-primary-800">Campus</span>
-              <span className="text-primary-500">Unify</span>
+            <h1 className="font-bold text-sm sm:text-xl flex flex-wrap">
+              <span className={`${isDarkMode ? 'text-primary-300' : 'text-primary-800'}`}>Campus</span>
+              <span className={`${isDarkMode ? 'text-primary-400' : 'text-primary-500'}`}>Unify</span>
             </h1>
           </div>
         </Link>
@@ -86,20 +81,11 @@ export default function Header() {
           {/* Dark/Light mode toggle button */}
           <li
             onClick={toggleDarkMode}
-            style={{
-              cursor: 'pointer',
-              padding: '8px',
-              borderRadius: '50%',
-              backgroundColor: isDarkMode ? '#444' : '#ddd',
-              transition: 'background-color 0.3s ease',
-            }}
+            className={`cursor-pointer p-2 rounded-full transition-colors duration-300 ${
+              isDarkMode ? 'bg-gray-700' : 'bg-gray-300'
+            }`}
           >
-            <span
-              style={{
-                fontSize: '20px',
-                color: isDarkMode ? '#fff' : '#000',
-              }}
-            >
+            <span className="text-lg">
               {isDarkMode ? '🌙' : '☀️'}
             </span>
           </li>

--- a/client/src/ui/Header.jsx
+++ b/client/src/ui/Header.jsx
@@ -1,8 +1,16 @@
+import { useState ,useContext} from 'react';
 import { Link } from 'react-router-dom';
 import { useUser } from '../features/authentication/useUser';
-
+import { Context } from '../main';
 export default function Header() {
   const { user } = useUser();
+  const { isDarkMode, setIsDarkMode } = useContext(Context);
+
+
+  // Function to toggle dark mode
+  const toggleDarkMode = () => {
+    setIsDarkMode((prevMode) => !prevMode);
+  };
 
   const renderUserLinks = () => {
     if (user?.role === 'user') {
@@ -51,19 +59,50 @@ export default function Header() {
   );
 
   return (
-    <header className="bg-[#fcfaf8] w-[80%] mx-auto">
+    <header
+      className="w-[80%] mx-auto"
+      style={{
+        backgroundColor: isDarkMode ? '#2D2D2D' : '#fcfaf8',
+        color: isDarkMode ? 'white' : 'black',
+      }}
+    >
       <div className="flex justify-between items-center mx-auto p-3">
         <Link to={user ? '/events' : '/'}>
           <div className="flex gap-4 items-center">
             <img src="/logo.png" className="h-12 w-12" alt="" />
-            <h1 className="font-bold text-sm sm:text-xl flex flex-wrap">
+            <h1
+              className="font-bold text-sm sm:text-xl flex flex-wrap"
+              style={{ color: isDarkMode ? '#fff' : '#000' }}
+            >
               <span className="text-primary-800">Campus</span>
               <span className="text-primary-500">Unify</span>
             </h1>
           </div>
         </Link>
+
         <ul className="flex gap-4 items-center">
           {user ? renderClubLinks() : renderGuestLinks()}
+
+          {/* Dark/Light mode toggle button */}
+          <li
+            onClick={toggleDarkMode}
+            style={{
+              cursor: 'pointer',
+              padding: '8px',
+              borderRadius: '50%',
+              backgroundColor: isDarkMode ? '#444' : '#ddd',
+              transition: 'background-color 0.3s ease',
+            }}
+          >
+            <span
+              style={{
+                fontSize: '20px',
+                color: isDarkMode ? '#fff' : '#000',
+              }}
+            >
+              {isDarkMode ? '🌙' : '☀️'}
+            </span>
+          </li>
         </ul>
       </div>
     </header>


### PR DESCRIPTION
I have added a dark/light mode toggle icon for easy switching between themes. It’s fully functional, offering smooth transitions and remembering your preference across pages. The icon changes (e.g., sun/moon) based on the active mode, enhancing user experience with real-time feedback.
![Screenshot (170)](https://github.com/user-attachments/assets/1870b798-6d1e-4447-a60a-de25cc3c8e1b)
